### PR TITLE
Node upgrade from 4 to ^8.9.4 and related

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,33 +163,20 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bossy": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
-      "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
+    "boom": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+      "integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
+        "hoek": "5.0.3"
       },
       "dependencies": {
-        "isemail": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
           "dev": true
-        },
-        "joi": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
-          }
         }
       }
     },
@@ -312,12 +299,20 @@
       "dev": true
     },
     "code": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/code/-/code-4.1.0.tgz",
-      "integrity": "sha1-IJrRHQWvigwceq9pTZ+k0sfZW4U=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/code/-/code-5.1.2.tgz",
+      "integrity": "sha512-Typ0BuWOKPGNOY9M7hBDY60J9uSPok4Y7hhtTG/3Cpqg0/AhauZSWax0Mb0lZuzm89w1YgVvl8BTrBW/4Sw6sw==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "5.0.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        }
       }
     },
     "color-convert": {
@@ -369,15 +364,6 @@
         "which": "1.3.0"
       }
     },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -406,77 +392,10 @@
         "rimraf": "2.6.2"
       }
     },
-    "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-      "dev": true
-    },
-    "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "eslint": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.5.0.tgz",
-      "integrity": "sha1-u3XTuL3pf7XhPvzVOXRGd/6wGcM=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.2.3",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      }
-    },
-    "eslint-config-hapi": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.1.0.tgz",
-      "integrity": "sha512-tAUedyvZla1qKt6jhOx7mj5tYDVCwdSyImpEK7wk/A/atKUjg18aHUK6Q6qWWM6rq21I1F/A8JAhIpkk0SvFMQ==",
       "dev": true
     },
     "eslint-plugin-hapi": {
@@ -500,6 +419,12 @@
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "espree": {
       "version": "3.5.1",
@@ -563,6 +488,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -633,12 +564,6 @@
         "once": "1.4.0",
         "path-is-absolute": "1.0.1"
       }
-    },
-    "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
     },
     "globby": {
       "version": "5.0.0",
@@ -850,12 +775,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-      "dev": true
-    },
     "joi": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-11.1.1.tgz",
@@ -904,6 +823,12 @@
         "jsonify": "0.0.0"
       }
     },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -926,29 +851,199 @@
       }
     },
     "lab": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-14.3.1.tgz",
-      "integrity": "sha512-sN14QhqiRuBGnfrOGo1B9UqiJJarEcZJEna/hGAT5g4uuxcowns4zc/JUBoMgT44jZgWBxbpjKPizBOGt5mYRw==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-15.2.1.tgz",
+      "integrity": "sha512-RzswRTnRLt2NICBvJX0xOaTS/pkVNQlbdcgcCoyxBbf9jv78H8PwU9OChzn2gFvVlQ46IZirFtnZdbD7238rQg==",
       "dev": true,
       "requires": {
-        "bossy": "3.0.4",
-        "code": "4.1.0",
-        "diff": "3.3.1",
-        "eslint": "4.5.0",
-        "eslint-config-hapi": "10.1.0",
+        "bossy": "4.0.1",
+        "diff": "3.4.0",
+        "eslint": "4.16.0",
+        "eslint-config-hapi": "11.1.0",
         "eslint-plugin-hapi": "4.0.0",
         "espree": "3.5.1",
         "find-rc": "3.0.1",
         "handlebars": "4.0.10",
-        "hoek": "4.2.0",
-        "items": "2.1.1",
+        "hoek": "5.0.3",
         "json-stable-stringify": "1.0.1",
         "json-stringify-safe": "5.0.1",
         "mkdirp": "0.5.1",
         "seedrandom": "2.4.3",
-        "source-map": "0.5.7",
-        "source-map-support": "0.4.18",
-        "supports-color": "4.4.0"
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.3",
+        "supports-color": "4.4.0",
+        "will-call": "1.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+          "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "bossy": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/bossy/-/bossy-4.0.1.tgz",
+          "integrity": "sha512-IrXZdXnDrjfk9ZVtnnmehlcTGK/KRqUJuNZJteMGU2/cJdXC6yWf2yhkAAbAgjOTsJJHXdlYloTeFH1ZgRNllw==",
+          "dev": true,
+          "requires": {
+            "boom": "7.1.1",
+            "hoek": "5.0.3",
+            "joi": "13.1.2"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2"
+          }
+        },
+        "eslint": {
+          "version": "4.16.0",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+          "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2",
+            "babel-code-frame": "6.26.0",
+            "chalk": "2.1.0",
+            "concat-stream": "1.6.0",
+            "cross-spawn": "5.1.0",
+            "debug": "3.1.0",
+            "doctrine": "2.1.0",
+            "eslint-scope": "3.7.1",
+            "eslint-visitor-keys": "1.0.0",
+            "espree": "3.5.3",
+            "esquery": "1.0.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "functional-red-black-tree": "1.0.1",
+            "glob": "7.1.2",
+            "globals": "11.3.0",
+            "ignore": "3.3.5",
+            "imurmurhash": "0.1.4",
+            "inquirer": "3.3.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.10.0",
+            "json-stable-stringify-without-jsonify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "7.0.0",
+            "progress": "2.0.0",
+            "require-uncached": "1.0.3",
+            "semver": "5.4.1",
+            "strip-ansi": "4.0.0",
+            "strip-json-comments": "2.0.1",
+            "table": "4.0.2",
+            "text-table": "0.2.0"
+          },
+          "dependencies": {
+            "espree": {
+              "version": "3.5.3",
+              "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+              "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+              "dev": true,
+              "requires": {
+                "acorn": "5.4.1",
+                "acorn-jsx": "3.0.1"
+              }
+            }
+          }
+        },
+        "eslint-config-hapi": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-11.1.0.tgz",
+          "integrity": "sha512-fCw0uLgkZLQBqYu/lR5MA6cXB+D4c2EEtzrVmhHbGQq3iRCFSaUEOE/N4Sujd1Qh5jkaUc0/kuB/gdv2upt5aQ==",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "dev": true
+        },
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        },
+        "joi": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.2.tgz",
+          "integrity": "sha512-bZZSQYW5lPXenOfENvgCBPb9+H6E6MeNWcMtikI04fKphj5tvFL9TOb+H2apJzbCrRw/jebjTH8z6IHLpBytGg==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.0.3",
+            "isemail": "3.0.0",
+            "topo": "3.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+          "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        },
+        "topo": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+          "dev": true,
+          "requires": {
+            "hoek": "5.0.3"
+          }
+        }
       }
     },
     "lazy-cache": {
@@ -1139,12 +1234,6 @@
         "pinkie": "2.0.4"
       }
     },
-    "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1317,16 +1406,8 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
+      "optional": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1483,6 +1564,12 @@
       "requires": {
         "isexe": "2.0.0"
       }
+    },
+    "will-call": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/will-call/-/will-call-1.0.1.tgz",
+      "integrity": "sha512-1hEeV8SfBYhNRc/bNXeQfyUBX8Dl9SCYME3qXh99iZP9wJcnhnlBsoBw8Y0lXVZ3YuPsoxImTzBiol1ouNR/hg==",
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Extends Joi with Joi.objectId()",
   "main": "lib/objectId.js",
   "scripts": {
-    "test": "lab -v -D -c"
+    "test": "lab -v -c"
   },
   "repository": {
     "type": "git",
@@ -25,15 +25,15 @@
   },
   "homepage": "https://github.com/wegolook/joi-objectid#readme",
   "devDependencies": {
-    "code": "^4.0.0",
+    "code": "^5.0.0",
     "joi": "^11.1.1",
-    "lab": "^14.3.1"
+    "lab": "^15.2.1"
   },
   "peerDependencies": {
     "joi": ">=9.0.0 <12.0.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": "^8.9.4"
   },
   "dependencies": {
     "bson": "^1.0.0"

--- a/test/objectId.js
+++ b/test/objectId.js
@@ -30,23 +30,21 @@ const invalidInput = gt24;
 
 describe('objectId', () => {
 
-  it('does not fail on undefined', (done) => {
+  it('does not fail on undefined', () => {
     Joi.objectId().validate(undefined, (err, value) => {
       expect(err).to.be.null();
-      expect(value).to.be.undefined()
-      done();
+      expect(value).to.be.undefined()    
     });
   });
 
-  it('fails on null', (done) => {
+  it('fails on null', () => {
     Joi.objectId().validate(null, (err, value) => {
       expect(err).to.exist();
       expect(value).to.be.null();
-      done();
     });
   });
 
-  it('fails on boolean', (done) => {
+  it('fails on boolean', () => {
     Joi.objectId().validate(true, (err, value) => {
       expect(err).to.exist();
       expect(value).to.equal(true);
@@ -57,94 +55,83 @@ describe('objectId', () => {
       expect(value).to.equal(false);
     });
 
-    done();
   });
 
-  it('fails when fewer than 12 characters', (done) => {
+  it('fails when fewer than 12 characters', () => {
     Joi.objectId().validate(lt12, (err, value) => {
       expect(err).to.exist();
       expect(value).to.equal(lt12);
-      done();
     });
   });
 
-  it('fails when between 12 and 24 characters', (done) => {
+  it('fails when between 12 and 24 characters', () => {
     Joi.objectId().validate(between, (err, value) => {
       expect(err).to.exist();
       expect(value).to.equal(between);
-      done();
     });
   });
 
-  it('fails when greater than 24 characters', (done) => {
+  it('fails when greater than 24 characters', () => {
 
     Joi.objectId().validate(gt24, (err, value) => {
       expect(err).to.exist();
       expect(value).to.equal(gt24);
-      done();
     });
   });
 
-  it('fails on invalid input and convert disabled', (done) => {
+  it('fails on invalid input and convert disabled', () => {
     Joi.objectId().options({ convert: false }).validate(invalidInput, (err, value) => {
       expect(err).to.exist();
       expect(value).to.equal(invalidInput);
-      done();
     });
   });
 
-  it('succeeds on 12 character string', (done) => {
+  it('succeeds on 12 character string', () => {
     Joi.objectId().validate(id12, (err, value) => {
       expect(err).to.not.exist();
       expect(value instanceof ObjectId).to.be.true();
-      done();
     });
   });
 
-  it('succeeds on 24 character string', (done) => {
+  it('succeeds on 24 character string', () => {
     Joi.objectId().validate(id24, (err, value) => {
       expect(err).to.not.exist();
       expect(value instanceof ObjectId).to.be.true();
-      done();
     });
   });
 
-  it('matches the input string', (done) => {
+  it('matches the input string', () => {
     Joi.objectId().validate(id24, (err, value) => {
       expect(err).to.not.exist();
       expect(value instanceof ObjectId).to.be.true();
       expect(value.equals(id24)).to.be.true();
-      done();
     });
   });
 
-  it('succeeds on instance of ObjectId', (done) => {
+  it('succeeds on instance of ObjectId', () => {
     Joi.objectId().validate(ObjectId(id24), (err, value) => {
       expect(value instanceof ObjectId).to.be.true();
       expect(value.equals(ObjectId(id24))).to.be.true();
-      done();
     });
   });
 
-  it('succeeds on valid input and convert disabled', (done) => {
+  it('succeeds on valid input and convert disabled', () => {
     Joi.objectId().options({ convert: false }).validate(id24, (err, value) => {
       expect(err).to.not.exist();
       expect(value).to.equal(id24);
-      done();
     });
   });
 
-  it('has a useful error message', (done) => {
+  it('has a useful error message', () => {
     const result = Joi.objectId().validate(lt12);
     expect(result.error.message).to.equal('"value" must be a valid ObjectId');
-    done();
   });
 
-  it('returns the original value given an invalid input', (done) => {
+  it('returns the original value given an invalid input', () => {
 
     const result = Joi.objectId().validate(lt12);
 
     expect(result.value).to.equal(lt12);
-    done();
+
   });
 });


### PR DESCRIPTION
- Upgraded node from >= 4.0.0. to ^8.9.4
- upgraded lab and code one major version to fit with node 8, 
- updated test suite to remove functions deprecated in lab 15 (-D is no longer a valid command line param and done() is no longer a function)

test suite claims 100% code coverage and all passing